### PR TITLE
Update carousel.vue

### DIFF
--- a/lib/carousel.vue
+++ b/lib/carousel.vue
@@ -172,13 +172,13 @@ export default {
         case "prev":
           changeLeftTranslate();
           state.currentIndex -= 1;
-          if (state.currentIndex === -1) {
+          if (state.currentIndex <= -1) {
             state.currentIndex = state.CAROUSEL_ITEM_LEN - 1;
           }
           break;
         case "next":
           state.currentIndex += 1;
-          if (state.currentIndex === state.CAROUSEL_ITEM_LEN) {
+          if (state.currentIndex >= state.CAROUSEL_ITEM_LEN) {
             state.currentIndex = 0;
           }
           break;


### PR DESCRIPTION
修复Carousel组件选项initIndex设置的比较实际CarouselItem数量值大时导致currentIndex不断增加后无法显示图片的问题